### PR TITLE
Fix set division callback on gui thread

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -51,8 +51,6 @@ SideChainAudioProcessorEditor::SideChainAudioProcessorEditor(SideChainAudioProce
   auto *parameter = p.GetAPVTS().getParameter("divisions");
   divisionMenu.addItemList(parameter->getAllValueStrings(), 1);
 
-  //divisionMenu.onChange = [this]
-  //{ divisionMenuChanged(); };
   divisionMenu.setSelectedId(2);
 
   divisionChoiceAttachment = std::make_unique<juce::AudioProcessorValueTreeState::ComboBoxAttachment>(p.GetAPVTS(), "divisions", divisionMenu);
@@ -67,30 +65,9 @@ SideChainAudioProcessorEditor::~SideChainAudioProcessorEditor()
 
 void SideChainAudioProcessorEditor::OnModeTextClicked()
 {
-  DynamicCurveEditor.SetDragAreaMode(!DynamicCurveEditor.GetDragAreaMode());  
+  DynamicCurveEditor.SetDragAreaMode(!DynamicCurveEditor.GetDragAreaMode());
   repaint();
 }
-
-//void SideChainAudioProcessorEditor::divisionMenuChanged()
-//{
-// /* switch (divisionMenu.getSelectedId())
-//  {
-//  case 1:
-//    audioProcessor.envelopeProcessor.SetDivisions(2);
-//    break;
-//  case 2:
-//    audioProcessor.envelopeProcessor.SetDivisions(1);
-//    break;
-//  case 3:
-//    audioProcessor.envelopeProcessor.SetDivisions(0.5);
-//    break;
-//  case 4:
-//    audioProcessor.envelopeProcessor.SetDivisions(0.25);
-//    break;
-//  default:
-//    break;
-//  }*/
-//}
 
 //==============================================================================
 void SideChainAudioProcessorEditor::paint(juce::Graphics &g)

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -51,8 +51,8 @@ SideChainAudioProcessorEditor::SideChainAudioProcessorEditor(SideChainAudioProce
   auto *parameter = p.GetAPVTS().getParameter("divisions");
   divisionMenu.addItemList(parameter->getAllValueStrings(), 1);
 
-  divisionMenu.onChange = [this]
-  { divisionMenuChanged(); };
+  //divisionMenu.onChange = [this]
+  //{ divisionMenuChanged(); };
   divisionMenu.setSelectedId(2);
 
   divisionChoiceAttachment = std::make_unique<juce::AudioProcessorValueTreeState::ComboBoxAttachment>(p.GetAPVTS(), "divisions", divisionMenu);
@@ -67,31 +67,30 @@ SideChainAudioProcessorEditor::~SideChainAudioProcessorEditor()
 
 void SideChainAudioProcessorEditor::OnModeTextClicked()
 {
-  DynamicCurveEditor.SetDragAreaMode(!DynamicCurveEditor.GetDragAreaMode());
+  DynamicCurveEditor.SetDragAreaMode(!DynamicCurveEditor.GetDragAreaMode());  
   repaint();
 }
 
-void SideChainAudioProcessorEditor::divisionMenuChanged()
-{
-
-  switch (divisionMenu.getSelectedId())
-  {
-  case 1:
-    audioProcessor.envelopeProcessor.SetDivisions(2);
-    break;
-  case 2:
-    audioProcessor.envelopeProcessor.SetDivisions(1);
-    break;
-  case 3:
-    audioProcessor.envelopeProcessor.SetDivisions(0.5);
-    break;
-  case 4:
-    audioProcessor.envelopeProcessor.SetDivisions(0.25);
-    break;
-  default:
-    break;
-  }
-}
+//void SideChainAudioProcessorEditor::divisionMenuChanged()
+//{
+// /* switch (divisionMenu.getSelectedId())
+//  {
+//  case 1:
+//    audioProcessor.envelopeProcessor.SetDivisions(2);
+//    break;
+//  case 2:
+//    audioProcessor.envelopeProcessor.SetDivisions(1);
+//    break;
+//  case 3:
+//    audioProcessor.envelopeProcessor.SetDivisions(0.5);
+//    break;
+//  case 4:
+//    audioProcessor.envelopeProcessor.SetDivisions(0.25);
+//    break;
+//  default:
+//    break;
+//  }*/
+//}
 
 //==============================================================================
 void SideChainAudioProcessorEditor::paint(juce::Graphics &g)

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -205,7 +205,7 @@ class SideChainAudioProcessorEditor : public juce::AudioProcessorEditor
 public:
     explicit SideChainAudioProcessorEditor(SideChainAudioProcessor &);
     void OnModeTextClicked();
-    void divisionMenuChanged();
+    //void divisionMenuChanged();
     ~SideChainAudioProcessorEditor() override;
 
     //==============================================================================

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -45,7 +45,10 @@ SideChainAudioProcessor::SideChainAudioProcessor()
     apvts.addParameterListener("divisions", this);
 }
 
-SideChainAudioProcessor::~SideChainAudioProcessor() = default;
+SideChainAudioProcessor::~SideChainAudioProcessor()
+{
+    apvts.removeParameterListener("divisions", this);
+};
 
 //==============================================================================
 const juce::String SideChainAudioProcessor::getName() const
@@ -139,7 +142,7 @@ bool SideChainAudioProcessor::isBusesLayoutSupported(const BusesLayout &layouts)
     if (layouts.getMainOutputChannelSet() != juce::AudioChannelSet::mono() && layouts.getMainOutputChannelSet() != juce::AudioChannelSet::stereo())
         return false;
 
-        // This checks if the input layout matches the output layout
+    // This checks if the input layout matches the output layout
 #if !JucePlugin_IsSynth
     if (layouts.getMainOutputChannelSet() != layouts.getMainInputChannelSet())
         return false;
@@ -235,7 +238,7 @@ float SideChainAudioProcessor::getRmsValue(const int channel) const
     return 0.f;
 }
 
-void SideChainAudioProcessor::parameterChanged(const juce::String& parameterID, float newValue)
+void SideChainAudioProcessor::parameterChanged(const juce::String &parameterID, float newValue)
 {
     if (parameterID == "divisions")
     {

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -41,6 +41,8 @@ SideChainAudioProcessor::SideChainAudioProcessor()
     curveManager = std::make_unique<CurveManager>(apvts);
     curveManager->registerOnCalculateDataPointsCallback([this](std::vector<juce::Point<float>> dataPoints)
                                                         { envelopeProcessor.setSideChainEnv(std::move(dataPoints)); });
+
+    apvts.addParameterListener("divisions", this);
 }
 
 SideChainAudioProcessor::~SideChainAudioProcessor() = default;
@@ -231,6 +233,31 @@ float SideChainAudioProcessor::getRmsValue(const int channel) const
         return rmsLevelRight.getCurrentValue();
 
     return 0.f;
+}
+
+void SideChainAudioProcessor::parameterChanged(const juce::String& parameterID, float newValue)
+{
+    if (parameterID == "divisions")
+    {
+        int setting = int(newValue);
+        switch (setting)
+        {
+        case 0:
+            envelopeProcessor.SetDivisions(2);
+            break;
+        case 1:
+            envelopeProcessor.SetDivisions(1);
+            break;
+        case 2:
+            envelopeProcessor.SetDivisions(0.5);
+            break;
+        case 3:
+            envelopeProcessor.SetDivisions(0.25);
+            break;
+        default:
+            break;
+        }
+    }
 }
 
 //==============================================================================

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -23,7 +23,7 @@ enum Divisions
 };
 
 //==============================================================================
-class SideChainAudioProcessor : public juce::AudioProcessor
+class SideChainAudioProcessor : public juce::AudioProcessor, juce::AudioProcessorValueTreeState::Listener
 {
 public:
   //==============================================================================
@@ -69,6 +69,8 @@ public:
   void callBack(std::vector<juce::Point<float>> d);
 
   juce::AudioProcessorValueTreeState &GetAPVTS() { return apvts; }
+
+  void parameterChanged(const juce::String& parameterID, float newValue) override;
 
   EnvelopeProcessor envelopeProcessor;
   Transport transport;


### PR DESCRIPTION
- moved division callback handler off of GUI thread to audio thread
- responds to host automation when GUI closed now
- atomically updating division value and loading value per block